### PR TITLE
feat: replacing ip package for ip-address package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Unleash/unleash-client-node",
   "dependencies": {
-    "ip": "^2.0.1",
+    "ip-address": "^9.0.5",
     "make-fetch-happen": "^12.0.0",
     "murmurhash3js": "^3.0.1",
     "semver": "^7.5.3"
@@ -48,7 +48,7 @@
     "@ava/typescript": "^4.0.0",
     "@tsconfig/node12": "^12.0.0",
     "@types/express": "^4.17.17",
-    "@types/ip": "^1.1.0",
+    "@types/jsbn": "^1.2.33",
     "@types/make-fetch-happen": "^10.0.1",
     "@types/murmurhash3js": "^3.0.3",
     "@types/nock": "^11.1.0",

--- a/src/strategy/remote-addresss-strategy.ts
+++ b/src/strategy/remote-addresss-strategy.ts
@@ -1,7 +1,6 @@
 import { Strategy } from './strategy';
 import { Context } from '../context';
-
-const ip = require('ip');
+import { Address4 } from 'ip-address';
 
 export default class RemoteAddressStrategy extends Strategy {
   constructor() {
@@ -16,14 +15,13 @@ export default class RemoteAddressStrategy extends Strategy {
       if (range === context.remoteAddress) {
         return true;
       }
-      if (!ip.isV6Format(range)) {
-        try {
-          return ip.cidrSubnet(range).contains(context.remoteAddress);
-        } catch (err) {
-          return false;
-        }
+      try {
+        const subnetRange = new Address4(range);
+        const remoteAddress = new Address4(context.remoteAddress || '');
+        return remoteAddress.isInSubnet(subnetRange);
+      } catch (err) {
+        return false;
       }
-      return false;
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,12 +657,10 @@
   resolved "https://registry.yarnpkg.com/@types/http-errors/-/http-errors-2.0.4.tgz#7eb47726c391b7345a6ec35ad7f4de469cf5ba4f"
   integrity sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==
 
-"@types/ip@^1.1.0":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@types/ip/-/ip-1.1.3.tgz#5d8634b3514a51768adda5e17c91a11cdb2e5247"
-  integrity sha512-64waoJgkXFTYnCYDUWgSATJ/dXEBanVkaP5d4Sbk7P6U7cTTMhxVyROTckc6JKdwCrgnAjZMn0k3177aQxtDEA==
-  dependencies:
-    "@types/node" "*"
+"@types/jsbn@^1.2.33":
+  version "1.2.33"
+  resolved "https://registry.yarnpkg.com/@types/jsbn/-/jsbn-1.2.33.tgz#470a4ff059f40fa6ca59838a8fa3f30c62a8c5ac"
+  integrity sha512-ZlLkHfu8xqqVFSbCe1FSPtAMUs7LKxk7TPskMb+sI5IbuzqyVqIEt9SVaQfFD2vrFcQunqKAmEBOuBEkoNLw4g==
 
 "@types/json-schema@^7.0.12":
   version "7.0.15"
@@ -2806,6 +2804,14 @@ internal-slot@^1.0.5:
     hasown "^2.0.0"
     side-channel "^1.0.4"
 
+ip-address@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-9.0.5.tgz#117a960819b08780c3bd1f14ef3c1cc1d3f3ea5a"
+  integrity sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==
+  dependencies:
+    jsbn "1.1.0"
+    sprintf-js "^1.1.3"
+
 ip@^2.0.0, ip@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.1.tgz#e8f3595d33a3ea66490204234b77636965307105"
@@ -3181,6 +3187,11 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+  integrity sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -4599,6 +4610,11 @@ spdx-license-ids@^3.0.0:
   version "3.0.16"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz#a14f64e0954f6e25cc6587bd4f392522db0d998f"
   integrity sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==
+
+sprintf-js@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.3.tgz#4914b903a2f8b685d17fdf78a70e917e872e444a"
+  integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Replacing `ip` pacakage for `ip-address` package to address https://nvd.nist.gov/vuln/detail/CVE-2024-29415.